### PR TITLE
Neovim does not support fixdel command anymore

### DIFF
--- a/indent/rst.vim
+++ b/indent/rst.vim
@@ -12,7 +12,11 @@ setlocal nosmartindent
 setlocal ww=b,s,<,>,[,]
 setlocal bs=indent,eol,start
 " NOTE: Fix del here, Does it have any sideeffects?
-fixdel
+
+if ! has('nvim')
+    " neovim got rid of the fixdel command
+    fixdel
+endif
 
 if exists("g:riv_disable_indent") && g:riv_disable_indent == 1
     " from vim74/indent/rst.vim


### PR DESCRIPTION
Hi,

Apparently, neovim removed the "fixdel" command, so this won't work properly anymore. Therefore I've changed the code to only run "fixdel" if we're NOT running in neovim.