### PR TITLE
Fix #94

### DIFF
--- a/autoload/riv/publish.vim
+++ b/autoload/riv/publish.vim
@@ -288,10 +288,10 @@ fun! s:single2(ft, file, browse) "{{{
             exe 'sp ' out_file
         elseif a:ft == "odt"
             " call s:sys(g:riv_ft_browser . ' '. shellescape(out_file) . ' &')
-            call riv#util#open(shellescape(out_file))
+            call riv#util#open(out_file)
         else
             " call s:sys(g:riv_web_browser . ' '. shellescape(out_file) . ' &')
-            call riv#util#open(shellescape(out_file))
+            call riv#util#open(out_file)
         endif
     endif
 endfun "}}}


### PR DESCRIPTION
The calling of riv#util#open() in s:single2() should not escape its arg
because it will get escaped in fucntion s:File.open() called by
riv#util#open(). Otherwise, it will escape the arg twice and thus
make it unusable.